### PR TITLE
No longer generates codes with more than two consecutive letters to prevent words/swear words from being generated.

### DIFF
--- a/EFCodeService.Tests/EFCodeService.Tests.csproj
+++ b/EFCodeService.Tests/EFCodeService.Tests.csproj
@@ -34,6 +34,9 @@
       <HintPath>..\packages\EntityFramework.5.0.0\lib\net45\EntityFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Moq">
+      <HintPath>..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
@@ -57,6 +60,9 @@
   <ItemGroup>
     <None Include="App.config" />
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/EFCodeService.Tests/packages.config
+++ b/EFCodeService.Tests/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EntityFramework" version="5.0.0" targetFramework="net45" />
+  <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
 </packages>

--- a/EFCodeService/EFCodeService.cs
+++ b/EFCodeService/EFCodeService.cs
@@ -1,10 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Data.Entity;
-using System.Text.RegularExpressions;
 using System.Diagnostics;
 
 namespace EFCodeService
@@ -13,8 +8,8 @@ namespace EFCodeService
     {
         internal const int MaxStringLength = 10;
         const int MAX_TRIES = 50;
-        DbContext _context;
-        int _codeLength;
+        readonly DbContext _context;
+        readonly int _codeLength;
         public EFCodeService(DbContext context, int codeLength)
         {
             _context = context;

--- a/EFCodeService/Utilities.cs
+++ b/EFCodeService/Utilities.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace EFCodeService
 {
@@ -11,12 +7,33 @@ namespace EFCodeService
     {
         public static string GenerateRandomString(int size, Random random)
         {
-            var chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+            const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+            const string numbers = "0123456789";
             var stringChars = new char[size];
 
-            for (int i = 0; i < stringChars.Length; i++)
+            var consecutiveLetters = 0;
+            for (var i = 0; i < stringChars.Length; i++)
             {
-                stringChars[i] = chars[random.Next(chars.Length)];
+                int index;
+                if (consecutiveLetters < 2)
+                {
+                    index = random.Next(chars.Length);
+                    stringChars[i] = chars[index];
+                    if (Char.IsLetter(chars[index]))
+                    {
+                        consecutiveLetters++;
+                    }
+                    else
+                    {
+                        consecutiveLetters = 0;
+                    }
+                }
+                else
+                {
+                    index = random.Next(numbers.Length);
+                    stringChars[i] = numbers[index];
+                    consecutiveLetters = 0;
+                }
             }
 
             return new String(stringChars);
@@ -31,7 +48,7 @@ namespace EFCodeService
 
         public static string GenerateSlug(this string phrase)
         {
-            string str = string.Empty;
+            string str;
             try
             {
                 str = phrase.RemoveAccent().ToLower();


### PR DESCRIPTION
Makes sure that codes generated do not create swear words or any other words.

Test Plan:
1. Run the automated test.
